### PR TITLE
Add ClawBench to Datasets / Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ So then you can easily copy and use this information in your pull requests.
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2506.08972)
   [![Website](https://img.shields.io/badge/Website-9cf)](https://ui-nexus.github.io/)
 
++ [ClawBench: Benchmarking Web Agents on Live Production Websites](https://arxiv.org/abs/2604.08523) (Apr. 2026)
+
+  [![Star](https://img.shields.io/github/stars/reacher-z/ClawBench.svg?style=social&label=Star)](https://github.com/reacher-z/ClawBench)
+  [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2604.08523)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://claw-bench.com)
+
 ## Models / Agents
 
 + [Grounding Open-Domain Instructions to Automate Web Support Tasks](https://web3.arxiv.org/abs/2103.16057) (Mar. 2021)


### PR DESCRIPTION
## Section fit

ClawBench is a GUI agent benchmark covering everyday web tasks on live production websites, which aligns with the **Datasets / Benchmarks** section. It is appended chronologically after the most recent entry (June 2025).

## What ClawBench is

- 153 everyday web tasks on 144 live production websites across 15 life categories
- 7 frontier models evaluated; the best passes 33.3%
- Unique mechanism: a submission-interception layer (Chrome extension + CDP) blocks only the final write request, letting agents run end-to-end on live sites without real-world side effects

## Public references

- Paper: https://arxiv.org/abs/2604.08523
- Repo: https://github.com/reacher-z/ClawBench
- Site: https://claw-bench.com

## Entry format

Follows the existing section convention: `+ [Title](paper link) (Month. Year)` with Star / arXiv / Website shields beneath.

## Affiliation disclosure

I am affiliated with the ClawBench project.