### PR TITLE
Add OpenAgent to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,11 @@ Multimodal Agents are Susceptible to Environmental Distractions](https://arxiv.o
 
 + [AGI Computer Control](https://github.com/James4Ever0/agi_computer_control)
 
++ [OpenAgent](https://github.com/the-open-agent/openagent)
+
+  [![Star](https://img.shields.io/github/stars/the-open-agent/openagent.svg?style=social&label=Star)](https://github.com/the-open-agent/openagent)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://www.openagentai.org/)
+
 + [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter)
 
   [![Star](https://img.shields.io/github/stars/OpenInterpreter/open-interpreter.svg?style=social&label=Star)](https://github.com/OpenInterpreter/open-interpreter)


### PR DESCRIPTION
Thank you for maintaining this resource for the GUI and computer-control agent community.

This PR adds **OpenAgent** ([repository](https://github.com/the-open-agent/openagent)) under **Projects**. It is an open-source system with strong emphasis on browser automation, broader computer-use workflows, and coding agents, with a self-hosted deployment path—so it fits alongside other runnable projects in this section rather than the paper list.

- **Website:** https://www.openagentai.org  
- **Demo:** https://demo.openagentai.org  

We are happy to tweak wording or placement if you prefer another heading.