### PR TITLE
Add ClawBench (arXiv:2604.08523) to Datasets / Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ So then you can easily copy and use this information in your pull requests.
 **Quick Navigation**: [[Datasets / Benchmarks]](#datasets--benchmarks) [[Models / Agents]](#models--agents) [[Surveys]](#surveys) [[Projects]](#projects)
 
 ## Datasets / Benchmarks
+
++ [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523) (May. 2026) — 283 everyday tasks (V1+V2) on live production websites; HTTP-interception + LLM-judge scoring; [code](https://github.com/reacher-z/ClawBench), [live leaderboard](https://claw-bench.com)
 + [World of Bits: An Open-Domain Platform for Web-Based Agents](https://proceedings.mlr.press/v70/shi17a.html) (Aug. 2017, ICML 2017)
 
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://proceedings.mlr.press/v70/shi17a/shi17a.pdf)


### PR DESCRIPTION
Adds **ClawBench** to **Datasets / Benchmarks**.

ClawBench evaluates GUI/browser agents on **live production websites** (Uber Eats, Indeed, Craigslist, etc., not Docker mocks). Two-stage scoring: deterministic HTTP-request **interception** at per-task URL/method schema + **LLM judge** on the intercepted payload.

- arXiv: https://arxiv.org/abs/2604.08523 (May 2026)
- 283 tasks (V1 153 + V2 130) across 163 live platforms · 15 life categories
- Code: https://github.com/reacher-z/ClawBench · Live: https://claw-bench.com

Direct conversation partner with WebArena / VisualWebArena / OSWorld / Mobile-Env (already listed).

Affiliation: I'm one of the maintainers.
