### PR TITLE
Add gui-tool to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,10 @@ Multimodal Agents are Susceptible to Environmental Distractions](https://arxiv.o
   [![Star](https://img.shields.io/github/stars/showlab/computer_use_ootb.svg?style=social&label=Star)](https://github.com/showlab/computer_use_ootb/tree/master)
   [![Website](https://img.shields.io/badge/Website-9cf)](https://computer-use-ootb.github.io/)
 
++ [gui-tool: Zero-dependency cross-platform GUI automation CLI for AI agents](https://github.com/ZachRouan/agent-desktop-interface)
+
+  [![Star](https://img.shields.io/github/stars/ZachRouan/agent-desktop-interface.svg?style=social&label=Star)](https://github.com/ZachRouan/agent-desktop-interface)
+
 ## Safety
 
 + [Adversarial Attacks on Multimodal Agents](https://github.com/ChenWu98/agent-attack)

--- a/README.md
+++ b/README.md
@@ -876,9 +876,9 @@ Multimodal Agents are Susceptible to Environmental Distractions](https://arxiv.o
   [![Star](https://img.shields.io/github/stars/showlab/computer_use_ootb.svg?style=social&label=Star)](https://github.com/showlab/computer_use_ootb/tree/master)
   [![Website](https://img.shields.io/badge/Website-9cf)](https://computer-use-ootb.github.io/)
 
-+ [gui-tool: Zero-dependency cross-platform GUI automation CLI for AI agents](https://github.com/ZachRouan/agent-desktop-interface)
++ [gridhand: Zero-dependency cross-platform GUI automation CLI for AI agents](https://github.com/ZachRouan/gridhand)
 
-  [![Star](https://img.shields.io/github/stars/ZachRouan/agent-desktop-interface.svg?style=social&label=Star)](https://github.com/ZachRouan/agent-desktop-interface)
+  [![Star](https://img.shields.io/github/stars/ZachRouan/gridhand.svg?style=social&label=Star)](https://github.com/ZachRouan/gridhand)
 
 ## Safety
 


### PR DESCRIPTION
Adds **gui-tool** to the Projects section — a zero-dependency Rust CLI for cross-platform GUI automation (Linux/macOS/Windows), built for AI agents.

It's screenshot-first: the agent picks targets by referencing a labeled grid cell overlaid on a screenshot (with recursive zoom for precision), rather than reading the accessibility tree. Strict JSON in/out, and it runs natively on GNOME/Wayland. Sits alongside PyAutoGUI / nut.js as a low-level actuation tool.

Repo: https://github.com/ZachRouan/agent-desktop-interface