### PR TITLE
Add ClawBench to GUI-agent benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ So then you can easily copy and use this information in your pull requests.
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2506.08972)
   [![Website](https://img.shields.io/badge/Website-9cf)](https://ui-nexus.github.io/)
 
++ [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523) (Apr. 2026)
+
+  [![Code](https://img.shields.io/badge/Code-GitHub-black)](https://github.com/reacher-z/ClawBench)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://claw-bench.com/)
+
 ## Models / Agents
 
 + [Grounding Open-Domain Instructions to Automate Web Support Tasks](https://web3.arxiv.org/abs/2103.16057) (Mar. 2021)


### PR DESCRIPTION
Adds ClawBench to the Datasets / Benchmarks section, following the list’s chronological format and badge conventions. Links the paper, code repository, and project page.

Submitted by reacher-z (mtrxcop@gmail.com). No co-authors.