### PR TITLE
Add Clickyy — open-source macOS menu bar screen-aware AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Awesome GUI Agent [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) <!-- omit in toc -->
 
+- [Clickyy](https://github.com/jayamitkatariya/clickyyy) - Open-source macOS menu bar AI agent: shake cursor to summon an overlay that sees your screen and can click, type, and act.
 A curated list of papers, projects, and resources for multi-modal Graphical User Interface (GUI) agents.
 
 <p align="center">


### PR DESCRIPTION
Add [Clickyy](https://github.com/jayamitkatariya/clickyyy) — an open-source macOS menu bar agent. Shake your cursor to summon an overlay that takes a real screenshot, answers questions about the screen, and in Agent mode clicks/types/drags/scrolls to complete tasks, with per-action approval and stuck-detection safety. MIT licensed; fits this list's GUI/computer-use agent focus.