### PR TITLE
Add Optics-Framework to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,11 @@ Multimodal Agents are Susceptible to Environmental Distractions](https://arxiv.o
 
   [![Star](https://img.shields.io/github/stars/X-PLUG/MobileAgent.svg?style=social&label=Star)](https://github.com/X-PLUG/MobileAgent)
 
++ [Optics-Framework: Self-healing GUI automation for mobile, web and Smart TV with an NL agent mode and MCP server](https://github.com/mozarkai/optics-framework)
+
+  [![Star](https://img.shields.io/github/stars/mozarkai/optics-framework.svg?style=social&label=Star)](https://github.com/mozarkai/optics-framework)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://mozarkai.github.io/optics-framework/)
+
 + [OpenUI](https://github.com/wandb/openui)
 
   [![Star](https://img.shields.io/github/stars/wandb/openui.svg?style=social&label=Star)](https://github.com/wandb/openui)


### PR DESCRIPTION
Adds [optics-framework](https://github.com/mozarkai/optics-framework) to **Projects**, next to Mobile-Agent which it most resembles.

- **NL agent mode**: bounded ReAct loop (screenshot → LLM → validated action → execute) operating live Android/iOS/web/Smart TV apps.
- **MCP server (`optics mcp`)**: exposes UI keywords (tap, swipe, enter text, verify, screenshot, page source) as MCP tools/resources so LLM clients can drive real devices.
- Production backbone: CSV/YAML keyword tests over Appium/Selenium/Playwright with self-healing locator fallback (XPath → text → OCR → image).

Apache-2.0, actively maintained. Entry follows the section's `+ [Name](url)` + Star/Website badge format.