### PR TITLE
Add Agent QA to GUI agent projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,10 @@ Multimodal Agents are Susceptible to Environmental Distractions](https://arxiv.o
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2504.19838)
 
 ## Projects
++ [Agent QA: Natural-language regression testing for web, Android, and iOS applications](https://github.com/vostride/agent-qa)
+
+  [![Star](https://img.shields.io/github/stars/vostride/agent-qa.svg?style=social&label=Star)](https://github.com/vostride/agent-qa)
+
 + [PyAutoGUI](https://pyautogui.readthedocs.io/en/latest/index.html)
 
   [![Star](https://img.shields.io/github/stars/asweigart/pyautogui.svg?style=social&label=Star)](https://github.com/asweigart/pyautogui/tree/master)


### PR DESCRIPTION
## Summary

- Add Agent QA to the Projects section for its natural-language web, Android, and iOS application regression testing.
- Include the repository's standard live GitHub star badge.
- Preserve the surrounding project format without adding publication metadata or unsupported claims.

## Validation

- `git diff --check`
- Confirmed the canonical Agent QA URL and star-badge target are unique in the new project block.
- Searched repository code, issues, and pull requests for an existing Agent QA entry immediately before submission.

The README uses CRLF line endings. The focused edit normalizes only the `Projects` heading and adjacent PyAutoGUI entry line to LF; their visible text is unchanged.

## Disclosure

I am affiliated with Agent QA and Vostride and am proposing this listing on the project's behalf.
